### PR TITLE
Change the str representation of AppHookConfig

### DIFF
--- a/aldryn_apphooks_config/models.py
+++ b/aldryn_apphooks_config/models.py
@@ -15,6 +15,8 @@ class AppHookConfig(models.Model):
     namespace = models.CharField(max_length=100)
     app_data = AppDataField()
 
+    cmsapp = None
+
     class Meta:
         verbose_name = _(u'app-hook config')
         verbose_name_plural = _(u'app-hook configs')
@@ -27,4 +29,7 @@ class AppHookConfig(models.Model):
         super(AppHookConfig, self).save(*args, **kwargs)
 
     def __str__(self):
-        return _(u'%s / %s') % (self.type, self.namespace)
+        if self.cmsapp:
+            return _(u'%s / %s') % (self.cmsapp.name, self.namespace)
+        else:
+            return _(u'%s / %s') % (self.type, self.namespace)


### PR DESCRIPTION
by using the related CMSApp name instead of the type