### PR TITLE
Remove django-cms 3.0.90a1 in favor of 3.0.9 stable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'django-appdata',
-        'django-cms>=3.0.90a1',
-    ],
-    dependency_links=[
-        'https://github.com/yakky/django-cms/tarball/future/integration#egg=django-cms-3.0.90a1'
+        'django-cms>=3.0.9',
     ],
     test_suite='test_settings.run',
     license="BSD",


### PR DESCRIPTION
This PR remove django-cms 3.0.90a1 in favor of 3.0.9 stable. Also, 3.0.90a1 is a greater version  than 3.0.9 and a eventual 3.0.10:

```
>>> from distutils.version import LooseVersion
>>> LooseVersion('3.0.90a1') > LooseVersion('3.0.9')
True
>>> LooseVersion('3.0.90a1') > LooseVersion('3.0.10')
True
```