### PR TITLE
Add templatetag to simplify namespace url lookups

### DIFF
--- a/aldryn_apphooks_config/templatetags/namespace_extras.py
+++ b/aldryn_apphooks_config/templatetags/namespace_extras.py
@@ -19,6 +19,7 @@ def namespace_url(context, view_name, *args, **kwargs):
     if not 'current_app' in kwargs:
         kwargs['current_app'] = namespace
 
-    return urlresolvers.reverse('%s:%s' % (config.namespace, view_name),
-                                args=args,
-                                kwargs=kwargs)
+    return urlresolvers.reverse(
+        '{0:s}:{1:s}'.format(config.namespace, view_name),
+        args=args,
+        kwargs=kwargs)

--- a/aldryn_apphooks_config/templatetags/namespace_extras.py
+++ b/aldryn_apphooks_config/templatetags/namespace_extras.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from django import template
+from django.core import urlresolvers
+
+from ..utils import get_app_instance
+
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def namespace_url(context, view_name, *args, **kwargs):
+    """
+    Returns an absolute URL matching given view with its parameters.
+    """
+
+    namespace, config = get_app_instance(context['request'])
+    if not 'current_app' in kwargs:
+        kwargs['current_app'] = namespace
+
+    return urlresolvers.reverse('%s:%s' % (config.namespace, view_name),
+                                args=args,
+                                kwargs=kwargs)


### PR DESCRIPTION
* Based on @mkoistinen 's Example from here: https://github.com/aldryn/aldryn-newsblog/blob/master/aldryn_newsblog/views.py#L35
* Allows user to use a {% namespace_url %} in django templates