### PR TITLE
Add checks to get_app_instance to avoid Resolver404

### DIFF
--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from app_data import AppDataContainer, app_registry
 from cms.apphook_pool import apphook_pool
-from django.core.urlresolvers import resolve
+from django.core.urlresolvers import resolve, Resolver404
 
 
 def get_app_instance(request):
@@ -15,11 +15,16 @@ def get_app_instance(request):
     if getattr(request, 'current_page', None):
         app = apphook_pool.get_apphook(request.current_page.application_urls)
 
-    config = None
-    namespace = resolve(request.path_info).namespace
     if app and app.app_config:
-        config = app.get_config(namespace)
-    return namespace, config
+        try:
+            config = None
+            namespace = resolve(request.path).namespace
+            if app and app.app_config:
+                config = app.get_config(namespace)
+            return namespace, config
+        except Resolver404:
+            pass
+    return '', None
 
 
 def setup_config(form_class, config_model):


### PR DESCRIPTION
get_app_instance may interact with non apphook-config enabled applications where the config or the namespace is not available.
This must not cause any exception, but just an empty namespace