### PR TITLE
Issues/improved i18n support

### DIFF
--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-from app_data import AppDataContainer, app_registry
+
+from django.core.urlresolvers import resolve, Resolver404
 from django.db.models import ForeignKey
 from django.utils.translation import override, get_language_from_request
+
+from app_data import AppDataContainer, app_registry
 from cms.apphook_pool import apphook_pool
-from django.core.urlresolvers import resolve, Resolver404
 
 
 def get_app_instance(request):

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from app_data import AppDataContainer, app_registry
 from django.db.models import ForeignKey
+from django.utils.translation import override, get_language_from_request
 from cms.apphook_pool import apphook_pool
 from django.core.urlresolvers import resolve, Resolver404
 
@@ -19,8 +20,8 @@ def get_app_instance(request):
     if app and app.app_config:
         try:
             config = None
-            namespace = resolve(request.path).namespace
-            if app and app.app_config:
+            with override(get_language_from_request(request, check_path=True)):
+                namespace = resolve(request.path).namespace
                 config = app.get_config(namespace)
             return namespace, config
         except Resolver404:


### PR DESCRIPTION
Fixes an issue where get_app_instance() will fail when called from a CMSToolbar. This was caused by resolve() using the CMS operator's language rather than the current page's language.