### PR TITLE
AppHookConfigWidget: Only do the reload if there was not a choice already set.

### DIFF
--- a/aldryn_apphooks_config/widgets.py
+++ b/aldryn_apphooks_config/widgets.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from django import forms
 from django.utils.html import mark_safe
-from django.utils.translation import ugettext_lazy as _
 
 
 class AppHookConfigWidget(forms.Select):
@@ -16,9 +15,14 @@ class AppHookConfigWidget(forms.Select):
         <script>
         (function($) {
             $(document).ready(function () {
-                $('#%(id)s').change(function () {
-                    $(this).apphook_reload_admin('%(name)s', $("option:selected",$(this)).val());
-                });
+                var sel = $('#%(id)s');
+                if (!sel.val()) {
+                    sel.change(function () {
+                        $(this).apphook_reload_admin(
+                            '%(name)s', $("option:selected",$(this)).val()
+                        );
+                    });
+                }
             });
         })(django.jQuery);
         </script>


### PR DESCRIPTION
Fixes #24 

I'm not entirely sure if this is the 100% exact correct behaviour, but it seems a step in the right direction =)