### PR TITLE
Issues/safe namespace url

### DIFF
--- a/aldryn_apphooks_config/templatetags/apphooks_config_tags.py
+++ b/aldryn_apphooks_config/templatetags/apphooks_config_tags.py
@@ -6,6 +6,7 @@ from functools import partial
 
 from django import template
 from django.core import urlresolvers
+from django.core.urlresolvers import NoReverseMatch
 
 from ..utils import get_app_instance
 
@@ -17,10 +18,17 @@ register = template.Library()
 def namespace_url(context, view_name, *args, **kwargs):
     """
     Returns an absolute URL matching named view with its parameters and the
-    provided application instance namespace. If no namespace is passed as a
-    kwarg (or it is "" or None), this templatetag will look into the request
-    object for the app_config's namespace. If there is still no namespace found,
-    this tag will act like the normal {% url ... %} tag.
+    provided application instance namespace.
+
+    If no namespace is passed as a kwarg (or it is "" or None), this templatetag
+    will look into the request object for the app_config's namespace. If there
+    is still no namespace found, this tag will act like the normal {% url ... %}
+    template tag.
+
+    Normally, this tag will return whatever is returned by the ultimate call to
+    reverse, which also means it will raise NoReverseMatch if reverse() cannot
+    find a match. This behaviour can be override by suppling a 'default' kwarg
+    with the value of what should be returned when no match is found.
     """
 
     namespace = kwargs.pop('namespace', None)
@@ -31,11 +39,26 @@ def namespace_url(context, view_name, *args, **kwargs):
     if namespace:
         namespace += ":"
 
-    reverse = partial(urlresolvers.reverse, '{0:s}{1:s}'.format(namespace, view_name))
+    reverse = partial(
+        urlresolvers.reverse, '{0:s}{1:s}'.format(namespace, view_name))
 
-    if kwargs:
-        return reverse(kwargs=kwargs)
-    elif args:
-        return reverse(args=args)
-    else:
-        return reverse()
+    # We're explicitly NOT happy to just re-raise the exception, as that may
+    # adversely affect stack traces.
+    if 'default' not in kwargs:
+        if kwargs:
+            return reverse(kwargs=kwargs)
+        elif args:
+            return reverse(args=args)
+        else:
+            return reverse()
+        
+    default = kwargs.pop('default', None)
+    try:
+        if kwargs:
+            return reverse(kwargs=kwargs)
+        elif args:
+            return reverse(args=args)
+        else:
+            return reverse()
+    except NoReverseMatch:
+        return default

--- a/aldryn_apphooks_config/templatetags/apphooks_config_tags.py
+++ b/aldryn_apphooks_config/templatetags/apphooks_config_tags.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
+from functools import partial
+
 from django import template
 from django.core import urlresolvers
 
@@ -27,14 +31,11 @@ def namespace_url(context, view_name, *args, **kwargs):
     if namespace:
         namespace += ":"
 
+    reverse = partial(urlresolvers.reverse, '{0:s}{1:s}'.format(namespace, view_name))
+
     if kwargs:
-        return urlresolvers.reverse(
-            '{0:s}{1:s}'.format(namespace, view_name),
-            kwargs=kwargs)
+        return reverse(kwargs=kwargs)
     elif args:
-        return urlresolvers.reverse(
-            '{0:s}{1:s}'.format(namespace, view_name),
-            args=args)
+        return reverse(args=args)
     else:
-        return urlresolvers.reverse(
-            '{0:s}{1:s}'.format(namespace, view_name))
+        return reverse()


### PR DESCRIPTION
The templatetag {% namespace_url %} now has an OPTIONAL kwarg: 'default', which can contain (any) value that should be returned when the ultimate reverse() call returns NoReverseMatch.

If no 'default' kwarg is passed, the behaviour remains unchanged and the tag will happily raise a NoReverseMatch error if the underlying reverse() does.

All other exceptions raised will continue to be raised, regardless if 'default' was passed.