### PR TITLE
Get apphook config from obj + cache apphook config field lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ docs/_build
 #DB
 *.sqlite
 *.db
+
+# Coverage
+coverage_html

--- a/aldryn_apphooks_config/tests/test_config.py
+++ b/aldryn_apphooks_config/tests/test_config.py
@@ -1,21 +1,20 @@
 # -*- coding: utf-8 -*-
-
 import os.path
 
 from django.template import Template, RequestContext
-from aldryn_apphooks_config.utils import get_app_instance
-
-from cms import api
-from cms.apphook_pool import apphook_pool
-from cms.utils import get_cms_setting
 from django.core.urlresolvers import reverse
 from django.http import SimpleCookie
 from django.utils.encoding import force_text
 from django.utils.six import StringIO
 from django.conf import settings
+
+from cms import api
+from cms.apphook_pool import apphook_pool
+from cms.utils import get_cms_setting
+
 from djangocms_helper.base_test import BaseTestCase
 
-
+from ..utils import get_app_instance, get_apphook_field_names
 from .utils.example.models import (
     AnotherExampleConfig, ExampleConfig, Article, News, TranslatableArticle
 )
@@ -365,3 +364,23 @@ class AppHookConfigTestCase(BaseTestCase):
         template = Template('{% load apphooks_config_tags %}{% namespace_url "example_list" %}')
         response = template.render(context)
         self.assertEqual(response, self.page_2.get_absolute_url())
+
+    def test_apphook_field_name_discovery(self):
+        field_names = get_apphook_field_names(Article)
+        self.assertEqual(field_names, ['section'])
+
+        field_names = get_apphook_field_names(TranslatableArticle)
+        self.assertEqual(field_names, ['section'])
+
+        field_names = get_apphook_field_names(News)
+        self.assertEqual(set(field_names), set(['config', 'section']))
+
+    def test_apphook_field_name_discovery_from_objects(self):
+        field_names = get_apphook_field_names(Article())
+        self.assertEqual(field_names, ['section'])
+
+        field_names = get_apphook_field_names(TranslatableArticle())
+        self.assertEqual(field_names, ['section'])
+
+        field_names = get_apphook_field_names(News())
+        self.assertEqual(set(field_names), set(['config', 'section']))

--- a/aldryn_apphooks_config/tests/test_config.py
+++ b/aldryn_apphooks_config/tests/test_config.py
@@ -384,3 +384,14 @@ class AppHookConfigTestCase(BaseTestCase):
 
         field_names = get_apphook_field_names(News())
         self.assertEqual(set(field_names), set(['config', 'section']))
+
+    # Not testable without migrations
+    # def test_apphook_object_discovery_from_objects(self):
+    #     field_names = get_apphook_configs(Article())
+    #     self.assertEqual(field_names, ['section'])
+    #
+    #     field_names = get_apphook_configs(TranslatableArticle())
+    #     self.assertEqual(field_names, ['section'])
+    #
+    #     field_names = get_apphook_configs(News())
+    #     self.assertEqual(set(field_names), set(['config', 'section']))

--- a/aldryn_apphooks_config/tests/test_config.py
+++ b/aldryn_apphooks_config/tests/test_config.py
@@ -16,7 +16,8 @@ from djangocms_helper.base_test import BaseTestCase
 
 from ..utils import get_app_instance, get_apphook_field_names
 from .utils.example.models import (
-    AnotherExampleConfig, ExampleConfig, Article, News, TranslatableArticle
+    AnotherExampleConfig, ExampleConfig, Article, News, TranslatableArticle,
+    NotApphookedModel
 )
 
 
@@ -375,6 +376,9 @@ class AppHookConfigTestCase(BaseTestCase):
         field_names = get_apphook_field_names(News)
         self.assertEqual(set(field_names), set(['config', 'section']))
 
+        field_names = get_apphook_field_names(NotApphookedModel)
+        self.assertEqual(field_names, [])
+
     def test_apphook_field_name_discovery_from_objects(self):
         field_names = get_apphook_field_names(Article())
         self.assertEqual(field_names, ['section'])
@@ -384,6 +388,9 @@ class AppHookConfigTestCase(BaseTestCase):
 
         field_names = get_apphook_field_names(News())
         self.assertEqual(set(field_names), set(['config', 'section']))
+
+        field_names = get_apphook_field_names(NotApphookedModel())
+        self.assertEqual(field_names, [])
 
     # Not testable without migrations
     # def test_apphook_object_discovery_from_objects(self):
@@ -395,3 +402,6 @@ class AppHookConfigTestCase(BaseTestCase):
     #
     #     field_names = get_apphook_configs(News())
     #     self.assertEqual(set(field_names), set(['config', 'section']))
+    #
+    #     field_names = get_apphook_configs(NotApphookedModel())
+    #     self.assertEqual(field_names, [])

--- a/aldryn_apphooks_config/tests/utils/example/models.py
+++ b/aldryn_apphooks_config/tests/utils/example/models.py
@@ -35,3 +35,6 @@ class TranslatableArticle(TranslatableModel):
     section = AppHookConfigField(ExampleConfig, verbose_name=_('section'))
 
     objects = AppHookConfigTranslatableManager()
+
+class NotApphookedModel(models.Model):
+    title = models.CharField(_('title'), max_length=234)

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -53,8 +53,9 @@ def _get_apphook_field_names(model):
             fields.append(field)
     return [field.name for field in fields]
 
+# making key app/model specific to avoid inheritance issues
+APP_CONFIG_FIELDS_KEY = '_{app_label}.{model_name}_app_config_field_names'
 
-APP_CONFIG_FIELDS_KEY = '_app_config_field_names'
 
 def get_apphook_field_names(model):
     """
@@ -63,10 +64,14 @@ def get_apphook_field_names(model):
     :param model: model
     :return: list of foreign key field names to AppHookConfigs
     """
-    if not hasattr(model, APP_CONFIG_FIELDS_KEY):
+    key = APP_CONFIG_FIELDS_KEY.format(
+        app_label=model._meta.app_label,
+        model_name=model._meta.object_name
+    ).lower()
+    if not hasattr(model, key):
         field_names = _get_apphook_field_names(model)
-        setattr(model, APP_CONFIG_FIELDS_KEY, field_names)
-    return getattr(model, APP_CONFIG_FIELDS_KEY)
+        setattr(model, key, field_names)
+    return getattr(model, key)
 
 
 def get_apphook_configs_from_obj(obj):
@@ -76,10 +81,14 @@ def get_apphook_configs_from_obj(obj):
     :param obj: any model instance
     :return: list of apphook configs for given obj
     """
-    if not hasattr(obj.__class__, APP_CONFIG_FIELDS_KEY):
+    key = APP_CONFIG_FIELDS_KEY.format(
+        app_label=obj.__class__._meta.app_label,
+        model_name=obj.__class__._meta.object_name
+    ).lower()
+    if not hasattr(obj.__class__, key):
         field_names = get_apphook_field_names(obj.__class__)
-        setattr(obj.__class__, APP_CONFIG_FIELDS_KEY, field_names)
-    keys = getattr(obj.__class__, APP_CONFIG_FIELDS_KEY)
+        setattr(obj.__class__, key, field_names)
+    keys = getattr(obj.__class__, key)
     return [getattr(obj, key) for key in keys] if keys else []
 
 

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -54,6 +54,22 @@ def get_apphook_field_names(model):
     return [field.name for field in fields]
 
 
+APP_CONFIG_FIELDS_KEY = '_app_config_field_names'
+
+def get_apphook_configs_from_obj(obj):
+    """
+    Get apphook configs for an object obj
+
+    :param obj: any model instance
+    :return: list of apphook configs for given obj
+    """
+    if not hasattr(obj.__class__, APP_CONFIG_FIELDS_KEY):
+        field_names = get_apphook_field_names(obj.__class__)
+        setattr(obj.__class__, APP_CONFIG_FIELDS_KEY, field_names)
+    keys = getattr(obj.__class__, APP_CONFIG_FIELDS_KEY)
+    return [getattr(obj, key) for key in keys] if keys else []
+
+
 def get_apphook_model(model, app_config_attribute):
     """
     Return the AppHookConfig model for the provided main model

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -54,7 +54,7 @@ def _get_apphook_field_names(model):
     return [field.name for field in fields]
 
 # making key app/model specific to avoid inheritance issues
-APP_CONFIG_FIELDS_KEY = '_app_config_field_names_{app_label}.{model_name}'
+APP_CONFIG_FIELDS_KEY = '_app_config_field_names_{app_label}_{model_name}'
 
 
 def get_apphook_field_names(model):

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -54,7 +54,7 @@ def _get_apphook_field_names(model):
     return [field.name for field in fields]
 
 # making key app/model specific to avoid inheritance issues
-APP_CONFIG_FIELDS_KEY = '_{app_label}.{model_name}_app_config_field_names'
+APP_CONFIG_FIELDS_KEY = '_app_config_field_names_{app_label}.{model_name}'
 
 
 def get_apphook_field_names(model):

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -59,9 +59,9 @@ APP_CONFIG_FIELDS_KEY = '_app_config_field_names_{app_label}.{model_name}'
 
 def get_apphook_field_names(model):
     """
-    Cache apphook field names on model
+    Cache app-hook field names on model
 
-    :param model: model
+    :param model: model class or object
     :return: list of foreign key field names to AppHookConfigs
     """
     key = APP_CONFIG_FIELDS_KEY.format(
@@ -74,7 +74,7 @@ def get_apphook_field_names(model):
     return getattr(model, key)
 
 
-def get_apphook_configs_from_obj(obj):
+def get_apphook_configs(obj):
     """
     Get apphook configs for an object obj
 
@@ -82,8 +82,8 @@ def get_apphook_configs_from_obj(obj):
     :return: list of apphook configs for given obj
     """
     key = APP_CONFIG_FIELDS_KEY.format(
-        app_label=obj.__class__._meta.app_label,
-        model_name=obj.__class__._meta.object_name
+        app_label=obj._meta.app_label,
+        model_name=obj._meta.object_name
     ).lower()
     if not hasattr(obj.__class__, key):
         field_names = get_apphook_field_names(obj.__class__)

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -81,14 +81,7 @@ def get_apphook_configs(obj):
     :param obj: any model instance
     :return: list of apphook configs for given obj
     """
-    key = APP_CONFIG_FIELDS_KEY.format(
-        app_label=obj._meta.app_label,
-        model_name=obj._meta.object_name
-    ).lower()
-    if not hasattr(obj.__class__, key):
-        field_names = get_apphook_field_names(obj.__class__)
-        setattr(obj.__class__, key, field_names)
-    keys = getattr(obj.__class__, key)
+    keys = get_apphook_field_names(obj)
     return [getattr(obj, key) for key in keys] if keys else []
 
 

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -41,7 +41,7 @@ def setup_config(form_class, config_model):
     app_registry.register('config', AppDataContainer.from_form(form_class), config_model)
 
 
-def get_apphook_field_names(model):
+def _get_apphook_field_names(model):
     """
     Return all foreign key field names for a AppHookConfig based model
     """
@@ -55,6 +55,19 @@ def get_apphook_field_names(model):
 
 
 APP_CONFIG_FIELDS_KEY = '_app_config_field_names'
+
+def get_apphook_field_names(model):
+    """
+    Cache apphook field names on model
+
+    :param model: model
+    :return: list of foreign key field names to AppHookConfigs
+    """
+    if not hasattr(model, APP_CONFIG_FIELDS_KEY):
+        field_names = _get_apphook_field_names(model)
+        setattr(model, APP_CONFIG_FIELDS_KEY, field_names)
+    return getattr(model, APP_CONFIG_FIELDS_KEY)
+
 
 def get_apphook_configs_from_obj(obj):
     """


### PR DESCRIPTION
Caches apphook config field names on model/class and adds a helper function to get all apphook configs from an object directly