### PR TITLE
AppHookConfigTranslatableManager.get_queryset should use queryset_class

### DIFF
--- a/aldryn_apphooks_config/managers/parler.py
+++ b/aldryn_apphooks_config/managers/parler.py
@@ -39,4 +39,4 @@ class AppHookConfigTranslatableManager(TranslatableManager, ManagerMixin):
     queryset_class = AppHookConfigTranslatableQueryset
 
     def get_queryset(self):
-        return AppHookConfigTranslatableQueryset(self.model, using=self.db)
+        return self.queryset_class(self.model, using=self.db)


### PR DESCRIPTION
Allow to extend AppHookConfigTranslatableManager