### PR TITLE
Skip overriding admin form if app_config field not present

### DIFF
--- a/aldryn_apphooks_config/admin.py
+++ b/aldryn_apphooks_config/admin.py
@@ -136,6 +136,8 @@ class ModelAppHookConfig(object):
         is used.
         """
         form = super(ModelAppHookConfig, self).get_form(request, obj, **kwargs)
+        if self.app_config_attribute not in form.base_fields:
+            return form
         app_config_default = self._app_config_select(request, obj)
         if app_config_default:
             form.base_fields[self.app_config_attribute].initial = app_config_default


### PR DESCRIPTION
e.g. when using ``FrontendEditableAdminMixin.edit_fields``