### PR TITLE
Allow overriding attributes for AppHookConfigField

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+0.2.8 (unreleased)
+++++++++++++++++++
+
+* Allow override AppHookConfigField attributes
+
 0.2.7 (2016-03-03)
 ++++++++++++++++++
 

--- a/aldryn_apphooks_config/fields.py
+++ b/aldryn_apphooks_config/fields.py
@@ -21,12 +21,14 @@ class AppHookConfigFormField(forms.ModelChoiceField):
 class AppHookConfigField(models.ForeignKey):
 
     def __init__(self, *args, **kwargs):
-        kwargs.update({'help_text': _('When selecting a value, the form is reloaded to '
-                                      'get the updated default')})
+        if 'help_text' not in kwargs:
+            kwargs.update({'help_text': _('When selecting a value, the form is reloaded to '
+                                          'get the updated default')})
         super(AppHookConfigField, self).__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
-        kwargs.update({'form_class': AppHookConfigFormField})
+        if 'form_class' not in kwargs:
+            kwargs.update({'form_class': AppHookConfigFormField})
         return super(AppHookConfigField, self).formfield(**kwargs)
 
 try:


### PR DESCRIPTION
Fix #42 