### PR TITLE
Allow use setup_config as decorators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,15 @@ Names are ``AppHookConfigTranslatableManager`` and
     # at the above step
     setup_config(BlogOptionForm, NewsBlogConfig)
 
+    # setup_config can be used as a decorator too, but the `model`
+    # attribute must be added to the form class
+    @setup_config
+    class BlogOptionForm(AppDataForm):
+        model = NewsBlogConfig
+
+
+
+
 * Define an admin class for the AppHookConfig model (usually in ``admin.py``::
 
     from django.contrib import admin

--- a/aldryn_apphooks_config/tests/utils/example/cms_appconfig.py
+++ b/aldryn_apphooks_config/tests/utils/example/cms_appconfig.py
@@ -17,12 +17,14 @@ class AnotherExampleConfig(AppHookConfig):
     max_entries = models.SmallIntegerField(default=5)
 
 
+@setup_config
 class ExampleConfigForm(AppDataForm):
+    model = ExampleConfig
     property = forms.CharField()
     published_default = forms.BooleanField(initial=True, required=False)
-setup_config(ExampleConfigForm, ExampleConfig)
 
 
+@setup_config
 class AnotherExampleConfigForm(AppDataForm):
+    model = AnotherExampleConfig
     property = forms.CharField()
-setup_config(AnotherExampleConfigForm, AnotherExampleConfig)

--- a/aldryn_apphooks_config/utils.py
+++ b/aldryn_apphooks_config/utils.py
@@ -33,13 +33,24 @@ def get_app_instance(request):
     return '', None
 
 
-def setup_config(form_class, config_model):
+def setup_config(form_class, config_model=None):
     """
     Register the provided form as config form for the provided config model
+
+    This can be used as a decorator by adding a `model` attribute to the config form::
+
+        @setup_config
+        class ExampleConfigForm(AppDataForm):
+            model = ExampleConfig
+
     :param form_class: Form class derived from AppDataForm
     :param config_model: Model class derived from AppHookConfig
     :return:
     """
+    # allow use as a decorator
+    if config_model is None:
+        return setup_config(form_class, form_class.model)
+
     app_registry.register('config', AppDataContainer.from_form(form_class), config_model)
 
 


### PR DESCRIPTION
This adds a bit of syntactic sugar by allowing to use `setup_config` as decorator