### PR TITLE
Require django-appdata>=0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django-appdata>=0.1.6',
+        'django-appdata>=0.2.0',
         'django-cms>=3.4'
     ],
     extra_requires={


### PR DESCRIPTION
Previous versions reference declared_fieldsets, which is no longer a ModelAdmin property since Django 1.9