### PR TITLE
Fix an error introduced by #54

### DIFF
--- a/aldryn_apphooks_config/tests/test_config.py
+++ b/aldryn_apphooks_config/tests/test_config.py
@@ -367,6 +367,7 @@ class AppHookConfigTestCase(BaseTestCase):
         request = self.get_page_request(self.page_3, self.user)
         response = admin_instance.add_view(request)
         self.assertContains(response, '$(this).apphook_reload_admin')
+        self.assertContains(response, 'var sel = $(\'#id_section\');')
         self.assertContains(response, 'aldryn_apphooks_config')
         self.assertContains(response, '<option value="1">%s</option>' % self.ns_app_1)
         self.assertContains(response, '<option value="2">%s</option>' % self.ns_app_2)

--- a/aldryn_apphooks_config/widgets.py
+++ b/aldryn_apphooks_config/widgets.py
@@ -23,5 +23,7 @@ class AppHookConfigWidget(forms.Select):
         else:
             final_attrs = self.build_attrs(attrs, name=name)
             final_attrs['DJANGO_110'] = True
+            final_attrs['widget'] = final_attrs
+            final_attrs['widget']['attrs'] = attrs
             script = render_to_string(self.template_name, context=final_attrs)
             return mark_safe(script + out)


### PR DESCRIPTION
The widget template was adapted for django 1.11+ context, not the Django 1.10- one. This provides the correct contenxt data for proper widget rendering